### PR TITLE
Fix for OF 0.11.0

### DIFF
--- a/src/ofxQuadWarp.cpp
+++ b/src/ofxQuadWarp.cpp
@@ -64,15 +64,12 @@ void ofxQuadWarp::disableMouseControls() {
         return;
     }
     bMouseEnabled = false;
-    try {
-        ofRemoveListener(ofEvents().mouseMoved, this, &ofxQuadWarp::onMouseMoved);
-        ofRemoveListener(ofEvents().mousePressed, this, &ofxQuadWarp::onMousePressed);
-        ofRemoveListener(ofEvents().mouseDragged, this, &ofxQuadWarp::onMouseDragged);
-        ofRemoveListener(ofEvents().mouseReleased, this, &ofxQuadWarp::onMouseReleased);
-    }
-    catch(Poco::SystemException) {
-        return;
-    }
+    
+    ofRemoveListener(ofEvents().mouseMoved, this, &ofxQuadWarp::onMouseMoved);
+    ofRemoveListener(ofEvents().mousePressed, this, &ofxQuadWarp::onMousePressed);
+    ofRemoveListener(ofEvents().mouseDragged, this, &ofxQuadWarp::onMouseDragged);
+    ofRemoveListener(ofEvents().mouseReleased, this, &ofxQuadWarp::onMouseReleased);
+    
 }
 
 void ofxQuadWarp::enableKeyboardShortcuts() {
@@ -88,12 +85,9 @@ void ofxQuadWarp::disableKeyboardShortcuts() {
         return;
     }
     bKeyboardShortcuts = false;
-    try {
-        ofRemoveListener(ofEvents().keyPressed, this, &ofxQuadWarp::keyPressed);
-    }
-    catch(Poco::SystemException) {
-        return;
-    }
+    
+    ofRemoveListener(ofEvents().keyPressed, this, &ofxQuadWarp::keyPressed);
+    
 }
 
 //----------------------------------------------------- source / target points.
@@ -412,77 +406,44 @@ bool ofxQuadWarp::isShowing() {
 //----------------------------------------------------- save / load.
 void ofxQuadWarp::save(const string& path) {
     ofXml xml;
-    xml.addChild("quadwarp");
-    xml.setTo("quadwarp");
-    xml.addChild("src");
-    xml.setTo("src");
-    for(int i=0; i<4; i++) {
-        xml.addChild("point");
-        xml.setToChild(i);
-        xml.setAttribute("x", ofToString(srcPoints[i].x));
-        xml.setAttribute("y", ofToString(srcPoints[i].y));
-        xml.setToParent();
-    }
-    xml.setToParent();
-    xml.addChild("dst");
-    xml.setTo("dst");
-    for(int i=0; i<4; i++) {
-        xml.addChild("point");
-        xml.setToChild(i);
-        xml.setAttribute("x", ofToString(dstPoints[i].x));
-        xml.setAttribute("y", ofToString(dstPoints[i].y));
-        xml.setToParent();
-    }
-    xml.setToParent();
+    xml.appendChild("quadwarp");
+    ofXml& src = xml.getChild("quadwarp").appendChild("src");
     
-    xml.setToParent();
+	for (int i = 0; i < 4; i++) {
+        auto& t = src.appendChild("point");
+        t.setAttribute("x", ofToString(srcPoints[i].x));
+        t.setAttribute("y", ofToString(srcPoints[i].y));
+	}
+	
+	ofXml& dst = xml.getChild("quadwarp").appendChild("dst");
+    for (int i = 0; i < 4; i++) {
+        auto& t = dst.appendChild("point");
+        t.setAttribute("x", ofToString(dstPoints[i].x));
+        t.setAttribute("y", ofToString(dstPoints[i].y));
+    }
+    
     xml.save(path);
 }
 
 void ofxQuadWarp::load(const string& path) {
     ofXml xml;
-    bool bOk = xml.load(path);
-    if(bOk == false) {
-        return;
-    }
+    if (!xml.load(path)) return;
     
-    bOk = xml.setTo("quadwarp");
-    if(bOk == false) {
-        return;
-    }
+    ofXml& src = xml.getChild("quadwarp").getChild("src");
+    int i = 0;
+    for (auto& it = src.getChildren().begin(); it != src.getChildren().end(); it++) {
+        srcPoints[i].x = it->getAttribute("x").getFloatValue();
+        srcPoints[i].y = it->getAttribute("y").getFloatValue();
+        i++;
+	}
     
-    bOk = xml.setTo("src");
-    if(bOk == false) {
-        return;
-    }
-    
-    for(int i=0; i<xml.getNumChildren(); i++) {
-        bOk = xml.setToChild(i);
-        if(bOk == false) {
-            continue;
-        }
-        srcPoints[i].x = ofToFloat(xml.getAttribute("x"));
-        srcPoints[i].y = ofToFloat(xml.getAttribute("y"));
-        xml.setToParent();
-    }
-    xml.setToParent();
-    
-    bOk = xml.setTo("dst");
-    if(bOk == false) {
-        return;
-    }
-    
-    for(int i=0; i<xml.getNumChildren(); i++) {
-        bOk = xml.setToChild(i);
-        if(bOk == false) {
-            continue;
-        }
-        dstPoints[i].x = ofToFloat(xml.getAttribute("x"));
-        dstPoints[i].y = ofToFloat(xml.getAttribute("y"));
-        xml.setToParent();
-    }
-    xml.setToParent();
-    xml.setToParent();
+    ofXml& dst = xml.getChild("quadwarp").getChild("dst");
+    i = 0;
+    for (auto& it = dst.getChildren().begin(); it != dst.getChildren().end(); it++) {
+        dstPoints[i].x = it->getAttribute("x").getFloatValue();
+        dstPoints[i].y = it->getAttribute("y").getFloatValue();
+        i++;
+	}
 }
 
 //----------------------------------------------------- show / hide.

--- a/src/ofxQuadWarp.cpp
+++ b/src/ofxQuadWarp.cpp
@@ -409,13 +409,13 @@ void ofxQuadWarp::save(const string& path) {
     xml.appendChild("quadwarp");
     ofXml& src = xml.getChild("quadwarp").appendChild("src");
     
-	for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 4; i++) {
         auto& t = src.appendChild("point");
         t.setAttribute("x", ofToString(srcPoints[i].x));
         t.setAttribute("y", ofToString(srcPoints[i].y));
-	}
+    }
 	
-	ofXml& dst = xml.getChild("quadwarp").appendChild("dst");
+    ofXml& dst = xml.getChild("quadwarp").appendChild("dst");
     for (int i = 0; i < 4; i++) {
         auto& t = dst.appendChild("point");
         t.setAttribute("x", ofToString(dstPoints[i].x));
@@ -435,7 +435,7 @@ void ofxQuadWarp::load(const string& path) {
         srcPoints[i].x = it->getAttribute("x").getFloatValue();
         srcPoints[i].y = it->getAttribute("y").getFloatValue();
         i++;
-	}
+    }
     
     ofXml& dst = xml.getChild("quadwarp").getChild("dst");
     i = 0;
@@ -443,7 +443,7 @@ void ofxQuadWarp::load(const string& path) {
         dstPoints[i].x = it->getAttribute("x").getFloatValue();
         dstPoints[i].y = it->getAttribute("y").getFloatValue();
         i++;
-	}
+    }
 }
 
 //----------------------------------------------------- show / hide.

--- a/src/ofxQuadWarp.cpp
+++ b/src/ofxQuadWarp.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "ofxQuadWarp.h"
+#include "opencv2/calib3d.hpp"
 
 ofxQuadWarp::ofxQuadWarp() {
     anchorSize = 10;
@@ -407,17 +408,17 @@ bool ofxQuadWarp::isShowing() {
 void ofxQuadWarp::save(const string& path) {
     ofXml xml;
     xml.appendChild("quadwarp");
-    ofXml& src = xml.getChild("quadwarp").appendChild("src");
     
+    ofXml src = xml.getChild("quadwarp").appendChild("src");
     for (int i = 0; i < 4; i++) {
-        auto& t = src.appendChild("point");
+        auto t = src.appendChild("point");
         t.setAttribute("x", ofToString(srcPoints[i].x));
         t.setAttribute("y", ofToString(srcPoints[i].y));
     }
 	
-    ofXml& dst = xml.getChild("quadwarp").appendChild("dst");
+    ofXml dst = xml.getChild("quadwarp").appendChild("dst");
     for (int i = 0; i < 4; i++) {
-        auto& t = dst.appendChild("point");
+        auto t = dst.appendChild("point");
         t.setAttribute("x", ofToString(dstPoints[i].x));
         t.setAttribute("y", ofToString(dstPoints[i].y));
     }
@@ -429,17 +430,17 @@ void ofxQuadWarp::load(const string& path) {
     ofXml xml;
     if (!xml.load(path)) return;
     
-    ofXml& src = xml.getChild("quadwarp").getChild("src");
+    auto src = xml.getChild("quadwarp").getChild("src");
     int i = 0;
-    for (auto& it = src.getChildren().begin(); it != src.getChildren().end(); it++) {
+    for (auto it = src.getChildren().begin(); it != src.getChildren().end(); it++) {
         srcPoints[i].x = it->getAttribute("x").getFloatValue();
         srcPoints[i].y = it->getAttribute("y").getFloatValue();
         i++;
     }
     
-    ofXml& dst = xml.getChild("quadwarp").getChild("dst");
+    auto dst = xml.getChild("quadwarp").getChild("dst");
     i = 0;
-    for (auto& it = dst.getChildren().begin(); it != dst.getChildren().end(); it++) {
+    for (auto it = dst.getChildren().begin(); it != dst.getChildren().end(); it++) {
         dstPoints[i].x = it->getAttribute("x").getFloatValue();
         dstPoints[i].y = it->getAttribute("y").getFloatValue();
         i++;

--- a/src/ofxQuadWarp.cpp
+++ b/src/ofxQuadWarp.cpp
@@ -138,63 +138,22 @@ ofMatrix4x4 ofxQuadWarp::getMatrixInverse() const {
 }
 
 ofMatrix4x4 ofxQuadWarp::getMatrix(const ofPoint* srcPoints, const ofPoint* dstPoints) const {
-    
-	//we need our points as opencv points
-	//be nice to do this without opencv?
-	CvPoint2D32f cvsrc[4];
-	CvPoint2D32f cvdst[4];	
-    
-	//we set the warp coordinates
-	//source coordinates as the dimensions of our window
-	cvsrc[0].x = srcPoints[0].x;
-	cvsrc[0].y = srcPoints[0].y;
-	cvsrc[1].x = srcPoints[1].x;
-	cvsrc[1].y = srcPoints[1].y;
-	cvsrc[2].x = srcPoints[2].x;
-	cvsrc[2].y = srcPoints[2].y;
-	cvsrc[3].x = srcPoints[3].x;
-	cvsrc[3].y = srcPoints[3].y;
-    
-	cvdst[0].x = dstPoints[0].x;
-	cvdst[0].y = dstPoints[0].y;
-	cvdst[1].x = dstPoints[1].x;
-	cvdst[1].y = dstPoints[1].y;
-	cvdst[2].x = dstPoints[2].x;
-	cvdst[2].y = dstPoints[2].y;
-	cvdst[3].x = dstPoints[3].x;
-	cvdst[3].y = dstPoints[3].y;
-    
-	//we create a matrix that will store the results
-	//from openCV - this is a 3x3 2D matrix that is
-	//row ordered
-	CvMat * translate = cvCreateMat(3,3,CV_32FC1);
-	
-	//this is the slightly easier - but supposidly less
-	//accurate warping method 
-	//cvWarpPerspectiveQMatrix(cvsrc, cvdst, translate); 
-    
-    
-	//for the more accurate method we need to create
-	//a couple of matrixes that just act as containers
-	//to store our points  - the nice thing with this 
-	//method is you can give it more than four points!
-	
-	CvMat* src_mat = cvCreateMat(4, 2, CV_32FC1);
-	CvMat* dst_mat = cvCreateMat(4, 2, CV_32FC1);
-    
-	//copy our points into the matrixes
-	cvSetData(src_mat, cvsrc, sizeof(CvPoint2D32f));
-	cvSetData(dst_mat, cvdst, sizeof(CvPoint2D32f));
-    
+
+	//Store the source and destination points into cv::Mat matrices
+	cv::Mat src_mat = cv::Mat(4, 2, CV_32FC1);
+	cv::Mat dst_mat = cv::Mat(4, 2, CV_32FC1);
+	for (int i = 0; i < 4; i++) {
+		src_mat.at<float>(i, 0) = srcPoints[i].x;
+		src_mat.at<float>(i, 1) = srcPoints[i].y;
+		dst_mat.at<float>(i, 0) = dstPoints[i].x;
+		dst_mat.at<float>(i, 1) = dstPoints[i].y;
+	}
+
 	//figure out the warping!
 	//warning - older versions of openCV had a bug
 	//in this function.
-	cvFindHomography(src_mat, dst_mat, translate);
-    
-	//get the matrix as a list of floats
-	float *mat = translate->data.fl;
-    
-    
+	cv::Mat translate = cv::findHomography(src_mat, dst_mat);
+	
 	//we need to copy these values
 	//from the 3x3 2D openCV matrix which is row ordered
 	//
@@ -209,25 +168,25 @@ ofMatrix4x4 ofxQuadWarp::getMatrix(const ofPoint* srcPoints, const ofPoint* dstP
 	//		 [ ][ ][ ][ ]
 	//       [2][5][ ][9]
 	//       
-    
-    ofMatrix4x4 matrixTemp;
-	matrixTemp.getPtr()[0]  = mat[0];
-	matrixTemp.getPtr()[4]  = mat[1];
-	matrixTemp.getPtr()[12] = mat[2];
 	
-	matrixTemp.getPtr()[1]  = mat[3];
-	matrixTemp.getPtr()[5]  = mat[4];
-	matrixTemp.getPtr()[13] = mat[5];	
+	ofMatrix4x4 matrixTemp;
+	matrixTemp.getPtr()[0]  = translate.at<double>(0);
+	matrixTemp.getPtr()[4]  = translate.at<double>(1);
+	matrixTemp.getPtr()[12] = translate.at<double>(2);
 	
-	matrixTemp.getPtr()[3]  = mat[6];
-	matrixTemp.getPtr()[7]  = mat[7];
-	matrixTemp.getPtr()[15] = mat[8];
-    
-    cvReleaseMat(&translate);
-    cvReleaseMat(&src_mat);
-    cvReleaseMat(&dst_mat);
-
-    return matrixTemp;
+	matrixTemp.getPtr()[1]  = translate.at<double>(3);
+	matrixTemp.getPtr()[5]  = translate.at<double>(4);
+	matrixTemp.getPtr()[13] = translate.at<double>(5);
+	
+	matrixTemp.getPtr()[3]  = translate.at<double>(6);
+	matrixTemp.getPtr()[7]  = translate.at<double>(7);
+	matrixTemp.getPtr()[15] = translate.at<double>(8);
+	
+	translate.release();
+	src_mat.release();
+	dst_mat.release();
+	
+	return matrixTemp;
 }
 
 void ofxQuadWarp::update() {


### PR DESCRIPTION
OF 0.11.0 comes with an update of ofxOpenCv that removes the function used by this addon to compute the homography matrix. I've replaced the old function by the new one and also replaced the deprecated cvMat matrices by the newer cv::Mat matrices.

I've tested it with OF 0.11.0 and 0.10.1 with Visual Studio on Windows and it seems to work fine, but I don't have much experience working with openCV so it may contain bugs.

This pull request includes the updates made by @nama-gatsuo to fix the addon for OF 0.10.0.  See pull request #10.